### PR TITLE
Dropped how parameter from _drop_sparse_columns

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,14 @@
 =======
 History
 =======
+0.1.3 (2022-10-11)
+------------------
+* Drop the 'how' parameter from _drop_sparse_columns() for coherence with Pandas 1.5.0
+
 0.1.2 (2021-06-16)
 ------------------
-
 * Changed VolatilitySurface object to be able to accept a grid of volatilies instead of an OptionsData object
 
 0.1.0 (2021-03-10)
 ------------------
-
 * First release on PyPI.

--- a/volatilipy/__init__.py
+++ b/volatilipy/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Aaron Smith"""
 __email__ = "aaronsmith1234@gmail.com"
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # pylint: disable=unused-import
 

--- a/volatilipy/helper_functions.py
+++ b/volatilipy/helper_functions.py
@@ -364,7 +364,7 @@ def _drop_sparse_columns(option_df: pd.DataFrame, threshold=0.75) -> pd.DataFram
         pd.DataFrame: Dataframe with only columns filled in up to the specified threshold
     """
     not_as_sparse_columns = option_df.dropna(
-        axis=1, thresh=round(len(option_df.index) * threshold), how="any"
+        axis=1, thresh=round(len(option_df.index) * threshold)
     )
     return not_as_sparse_columns
 


### PR DESCRIPTION
Remove the 'how' parameter from method _drop_sparse_columns to work with Pandas 1.5.0

## Description
Beginning in Pandas 1.5, specifying both the 'thresh' and 'how' parameters for the pd.dropna method results in an error.

## Motivation and Context
Update to work with new Pandas version.

## How Has This Been Tested?
Validated all tests still successfully run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have bumped the version accordingly.

